### PR TITLE
fix: corrigir senha inicial do admin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,8 @@ POSTGRES_PORT=5432
 SPRING_JPA_HIBERNATE_DDL_AUTO=update
 SPRING_SQL_INIT_MODE=always
 
-JWT_SECRET_KEY=troque-por-uma-chave-hexadecimal-segura-com-pelo-menos-32-bytes
+# Chave local de desenvolvimento em Base64 com pelo menos 32 bytes. Troque em ambientes compartilhados/producao.
+JWT_SECRET_KEY=MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDE=
 JWT_EXPIRATION_TIME=3600000
 APP_CORS_ALLOWED_ORIGINS=http://localhost:4200
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN mvn clean package -DskipTests
 
 FROM eclipse-temurin:17-jre-alpine
 
-RUN apk add --no-cache wget
+RUN apk add --no-cache su-exec wget
 
 RUN addgroup -g 1001 -S appgroup && \
     adduser -u 1001 -S appuser -G appgroup
@@ -19,10 +19,13 @@ WORKDIR /app
 
 COPY --from=build /app/target/*.jar app.jar
 
-RUN mkdir -p /portifolium-files && \
-    chown -R appuser:appgroup /portifolium-files /app
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
-USER appuser
+RUN mkdir -p /portifolium-files /var/lib/portifolium/files && \
+    chown -R appuser:appgroup /portifolium-files /var/lib/portifolium /app && \
+    chmod +x /usr/local/bin/docker-entrypoint.sh
+
+USER root
 
 EXPOSE 8080
 
@@ -31,4 +34,5 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
 
 ENV JAVA_OPTS="-Xmx512m -Xms256m"
 
-ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar app.jar"]
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["sh", "-c", "java $JAVA_OPTS -jar app.jar"]

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ POSTGRES_PASSWORD=postgres
 POSTGRES_PORT=5432
 SPRING_JPA_HIBERNATE_DDL_AUTO=update
 SPRING_SQL_INIT_MODE=always
-JWT_SECRET_KEY=troque-por-uma-chave-segura
+JWT_SECRET_KEY=MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDE=
 JWT_EXPIRATION_TIME=3600000
 APP_CORS_ALLOWED_ORIGINS=http://localhost:4200
 FRONTEND_URL=http://localhost:4200
@@ -97,6 +97,8 @@ MAIL_PASSWORD=
 ```
 
 Por padrao, arquivos enviados ficam fora do repositorio Git. No Docker Compose, o volume local fica em `../portifolium-files` e e montado em `/var/lib/portifolium/files` dentro do container.
+
+`JWT_SECRET_KEY` deve ser uma chave em Base64 com pelo menos 32 bytes para HS256. O valor acima e apenas para desenvolvimento local; use outro valor em ambientes compartilhados ou producao.
 
 `APP_CORS_ALLOWED_ORIGINS` aceita multiplas origens separadas por virgula.
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+storage_dir="${FILE_STORAGE_LOCATION:-/var/lib/portifolium/files}"
+
+mkdir -p "$storage_dir"
+chown -R appuser:appgroup "$storage_dir" 2>/dev/null || chmod -R 0775 "$storage_dir"
+
+exec su-exec appuser:appgroup "$@"

--- a/src/main/resources/data-mysql.sql
+++ b/src/main/resources/data-mysql.sql
@@ -35,8 +35,13 @@ INSERT IGNORE INTO pessoa (id, nome, cpf, created_at, created_by, updated_at, up
 (1, 'Administrador do Sistema', '31452012040', NOW(), 'system', NOW(), 'system');
 
 -- Populando a tabela Usuario com níveis de acesso e senhas criptografadas
-INSERT IGNORE INTO usuario (id, email, senha, pessoa_id, created_at, updated_at) VALUES
-(1, 'admin@uea.edu.br', '$2a$10$hVfJIfpLdpbxwPiRfT2eheqDQlgklnzXZu81UYBa3bjOb5QtAAz.W', 1, NOW(), NOW()); -- Senha: admin123
+INSERT INTO usuario (id, email, senha, pessoa_id, created_at, updated_at) VALUES
+(1, 'admin@uea.edu.br', '$2a$10$hVfJIfpLdpbxwPiRfT2eheqDQlgklnzXZu81UYBa3bjOb5QtAAz.W', 1, NOW(), NOW()) -- Senha: admin123
+ON DUPLICATE KEY UPDATE
+email = VALUES(email),
+senha = VALUES(senha),
+pessoa_id = VALUES(pessoa_id),
+updated_at = NOW();
 
 
 

--- a/src/main/resources/data-mysql.sql
+++ b/src/main/resources/data-mysql.sql
@@ -36,7 +36,7 @@ INSERT IGNORE INTO pessoa (id, nome, cpf, created_at, created_by, updated_at, up
 
 -- Populando a tabela Usuario com níveis de acesso e senhas criptografadas
 INSERT IGNORE INTO usuario (id, email, senha, pessoa_id, created_at, updated_at) VALUES
-(1, 'admin@uea.edu.br', '$2a$10$Ebmi/uPZlhTEB7e39gsPTOfADOsL0IdEcEQllZyogM/WI/WKUMYdW', 1, NOW(), NOW()); -- Senha: secretario123
+(1, 'admin@uea.edu.br', '$2a$10$hVfJIfpLdpbxwPiRfT2eheqDQlgklnzXZu81UYBa3bjOb5QtAAz.W', 1, NOW(), NOW()); -- Senha: admin123
 
 
 

--- a/src/main/resources/data-postgresql.sql
+++ b/src/main/resources/data-postgresql.sql
@@ -44,9 +44,9 @@ INSERT INTO pessoa (id, nome, cpf, created_at, created_by, updated_at, updated_b
 ON CONFLICT (id) DO NOTHING;
 
 -- Populando a tabela Usuario (admin)
--- Senha: secretario123 (criptografada com BCrypt)
+-- Senha: admin123 (criptografada com BCrypt)
 INSERT INTO usuario (id, email, senha, pessoa_id, created_at, updated_at) VALUES
-(1, 'admin@uea.edu.br', '$2a$10$Ebmi/uPZlhTEB7e39gsPTOfADOsL0IdEcEQllZyogM/WI/WKUMYdW', 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+(1, 'admin@uea.edu.br', '$2a$10$hVfJIfpLdpbxwPiRfT2eheqDQlgklnzXZu81UYBa3bjOb5QtAAz.W', 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
 ON CONFLICT (id) DO NOTHING;
 
 -- Populando a tabela Usuario_Roles (associação admin com role de administrador)

--- a/src/main/resources/data-postgresql.sql
+++ b/src/main/resources/data-postgresql.sql
@@ -47,7 +47,11 @@ ON CONFLICT (id) DO NOTHING;
 -- Senha: admin123 (criptografada com BCrypt)
 INSERT INTO usuario (id, email, senha, pessoa_id, created_at, updated_at) VALUES
 (1, 'admin@uea.edu.br', '$2a$10$hVfJIfpLdpbxwPiRfT2eheqDQlgklnzXZu81UYBa3bjOb5QtAAz.W', 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
-ON CONFLICT (id) DO NOTHING;
+ON CONFLICT (id) DO UPDATE SET
+email = EXCLUDED.email,
+senha = EXCLUDED.senha,
+pessoa_id = EXCLUDED.pessoa_id,
+updated_at = CURRENT_TIMESTAMP;
 
 -- Populando a tabela Usuario_Roles (associação admin com role de administrador)
 INSERT INTO usuario_roles (usuario_id, role_id) VALUES

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -36,7 +36,7 @@ MERGE INTO pessoa (id, nome, cpf, created_at, created_by, updated_at, updated_by
 
 -- Populando a tabela Usuario com níveis de acesso e senhas criptografadas
 MERGE INTO usuario (id, email, senha, pessoa_id, created_at, updated_at) KEY(id) VALUES
-(1, 'admin@uea.edu.br', '$2a$10$Ebmi/uPZlhTEB7e39gsPTOfADOsL0IdEcEQllZyogM/WI/WKUMYdW', 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP); -- Senha: secretario123
+(1, 'admin@uea.edu.br', '$2a$10$hVfJIfpLdpbxwPiRfT2eheqDQlgklnzXZu81UYBa3bjOb5QtAAz.W', 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP); -- Senha: admin123
 
 
 

--- a/src/main/resources/data_.sql
+++ b/src/main/resources/data_.sql
@@ -82,7 +82,7 @@ MERGE INTO pessoa (id, nome, cpf, created_at, created_by, updated_at, updated_by
 
 -- Populando a tabela Usuario com níveis de acesso e senhas criptografadas
 MERGE INTO usuario (id, email, senha, pessoa_id, created_at, updated_at) KEY(id) VALUES
-(1, 'admin@uea.edu.br', '$2a$10$Ebmi/uPZlhTEB7e39gsPTOfADOsL0IdEcEQllZyogM/WI/WKUMYdW', 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP), -- Senha: admin123
+(1, 'admin@uea.edu.br', '$2a$10$hVfJIfpLdpbxwPiRfT2eheqDQlgklnzXZu81UYBa3bjOb5QtAAz.W', 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP), -- Senha: admin123
 (2, 'gerente1@uea.edu.br', '$2a$10$84EaPNF6J.4tAMWF8TrNduVFf7XOuUKJ8OmPMLbUR3vq3FiZilSk2', 2, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP), -- Senha: gerente123
 (3, 'gerente2@uea.edu.br', '$2a$10$84EaPNF6J.4tAMWF8TrNduVFf7XOuUKJ8OmPMLbUR3vq3FiZilSk2', 3, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP), -- Senha: gerente123
 (4, 'gerente3@uea.edu.br', '$2a$10$84EaPNF6J.4tAMWF8TrNduVFf7XOuUKJ8OmPMLbUR3vq3FiZilSk2', 4, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP), -- Senha: gerente123


### PR DESCRIPTION
## Resumo
- Corrige o hash BCrypt do usuario inicial admin@uea.edu.br para a senha admin123.
- Faz upsert do admin nos seeds MySQL/PostgreSQL para corrigir bancos ja inicializados com hash antigo.
- Ajusta o Docker para preparar permissoes do volume de arquivos antes de executar a aplicacao como appuser.
- Atualiza o exemplo/documentacao de JWT_SECRET_KEY para Base64 valido em desenvolvimento local.

## Validacoes
- ./mvnw test
- docker compose up -d --build app frontend
- POST http://localhost:4200/api/auth/login com admin@uea.edu.br/admin123 retornou token.