### PR TITLE
test: adicionar servico e2e ao compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,24 @@ URLs:
 O compose sobe apenas:
 
 - `app`: API Spring Boot
+- `frontend`: Angular servido por Nginx
 - `db`: PostgreSQL 15
+
+### Testes E2E com Playwright
+
+No repositorio frontend, use:
+
+```powershell
+npm run e2e
+```
+
+Esse comando executa o ambiente integrado via Docker Compose e retorna o exit code do servico `e2e`:
+
+```powershell
+docker compose --profile e2e up --build --abort-on-container-exit --exit-code-from e2e
+```
+
+Para rodar diretamente a partir deste diretorio, defina as variaveis necessarias e use o mesmo comando com o profile `e2e`.
 
 ## Configuracao
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,30 @@ services:
     depends_on:
       app:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost/ >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
     restart: unless-stopped
+
+  e2e:
+    build:
+      context: ../app-Portifolium-frontend
+      dockerfile: Dockerfile
+      target: e2e
+    image: portifolium-e2e:local
+    environment:
+      PLAYWRIGHT_BASE_URL: http://frontend
+    volumes:
+      - ../app-Portifolium-frontend/playwright-report:/app/playwright-report
+      - ../app-Portifolium-frontend/test-results:/app/test-results
+    depends_on:
+      frontend:
+        condition: service_healthy
+    profiles:
+      - e2e
 
   app:
     build:


### PR DESCRIPTION
## Resumo
- adiciona o servico e2e ao Docker Compose com profile dedicado
- adiciona healthcheck do frontend para coordenar a execucao dos testes
- documenta o fluxo Playwright via docker compose up --build --abort-on-container-exit --exit-code-from e2e

## Validacoes
- .\\mvnw.cmd test
- npm run build
- npm run e2e